### PR TITLE
Fix bitbucket server image address in values.yaml

### DIFF
--- a/bitbucket/values.yaml
+++ b/bitbucket/values.yaml
@@ -7,8 +7,8 @@ namespace: bitbucket
 replicaCount: 1
 proxyName: ""
 image:
-  repository: atlassian/bitbucket-server
-  tag: 8.7.1
+  repository: atlassian/bitbucket
+  tag: 8.19.14
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
It needs to use atlassian/bitbucket image address to install new versions of bitbucket server, e.g. 8.19.14

https://hub.docker.com/r/atlassian/bitbucket/tags?name=8.19.14